### PR TITLE
fix: buffer-alloc pads a buffer by repeating

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,9 @@ var nativeTimingSafeEqual = function nativeTimingSafeEqual(a, b) {
     var len = Math.max(Buffer.byteLength(strA), Buffer.byteLength(strB));
     
     var bufA = bufferAlloc(len, strA, 'utf8');
+    bufA.fill(0, Buffer.byteLength(strA));
     var bufB = bufferAlloc(len, strB, 'utf8');
+    bufB.fill(0, Buffer.byteLength(strB));
     
     return crypto.timingSafeEqual(bufA, bufB);
 };

--- a/test/test.js
+++ b/test/test.js
@@ -48,6 +48,10 @@ describe('safe compare', function () {
         it('"\\u00e8" against "\\u01e8"', function () {
             assert.equal(false, safeCompare('\u00e8', '\u01e8'));
         });
+        
+        it('"a" against "aaaaaaaaaa"', function () {
+            assert.equal(false, safeCompare('a', 'aaaaaaaaaa'));
+        });
     });
 
     describe('should not throw an error for non string argument', function () {


### PR DESCRIPTION
```
> require('safe-compare')('a', 'aaaaaaaaaaaaaaaaaaaaaa')
true
> require('safe-compare')('abc', 'abcabc')
true
```